### PR TITLE
Add font to texts on details page

### DIFF
--- a/details.css
+++ b/details.css
@@ -1,6 +1,9 @@
 body {
   background-color: #121317;
 }
+h1, span, p, a, div {
+  font-family: "Poppins", sans-serif;
+}
 ol li::marker
 {
   color:#58afd1;


### PR DESCRIPTION
Makes the texts on the details page have the same font as on the front page to make everything look a bit more polished and coherent